### PR TITLE
Update dependencies: actions/checkout, download-artifact, upload-artifact, cibuildwheel

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -82,7 +82,7 @@ jobs:
     
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           path: dist/
           merge-multiple: true

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for setuptools-scm
       
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v3.3.1
         env:
           # Build for Python 3.8-3.12
           CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -37,7 +37,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest pytest-cov numpy scipy
           CIBW_TEST_COMMAND: pytest {project}/tests -v
       
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
@@ -67,7 +67,7 @@ jobs:
       - name: Check metadata
         run: twine check dist/*
       
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: sdist
           path: dist/*.tar.gz

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for setuptools-scm
       
@@ -47,7 +47,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for setuptools-scm
       

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Fetch all history for setuptools-scm
     
@@ -61,7 +61,7 @@ jobs:
     needs: test
     
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Fetch all history for setuptools-scm
     


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the latest versions of several actions and tools, ensuring improved security, compatibility, and access to new features. The updates affect both the Python package testing and publishing workflows.