### PR TITLE
Bump actions/download-artifact to v8 and actions/upload-artifact to v7

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -82,7 +82,7 @@ jobs:
     
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: dist/
           merge-multiple: true

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -37,7 +37,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest pytest-cov numpy scipy
           CIBW_TEST_COMMAND: pytest {project}/tests -v
       
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
@@ -67,7 +67,7 @@ jobs:
       - name: Check metadata
         run: twine check dist/*
       
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist/*.tar.gz


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for publishing to PyPI, specifically by bumping the versions of the `actions/upload-artifact` and `actions/download-artifact` actions. These upgrades help ensure compatibility with the latest features and bug fixes provided by GitHub.